### PR TITLE
Demo prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,27 @@ Theia IDE Docker images for the CS46 class
 
 This is a helper script that creates a new container then starts it.
 
-It takes 1 command line argument:
+It takes 1 command line argument to start the container and add it to `theia-net`:
 
 ```
-./start user_name
+./start name
 ```
 
 For example:
 
 ```
 ./start zed
+```
+
+To test the container it takes 2 arguments, the name and port number to publish:
+
+```
+./start name port
+```
+
+For example:
+
+```
+./start zed 3000
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Theia IDE Docker images for the CS46 class
 
 This is a helper script that creates a new container then starts it.
 
-It takes 2 command line arguments:
+It takes 1 command line argument:
 
 ```
-./start port_number user_name
+./start user_name
 ```
 
 For example:
 
 ```
-./start 3000 zed
+./start zed
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Theia IDE Docker images for the CS46 class
 
 ### start.sh
 
-This is a helper script that creates a new container then starts it.
+This is a helper script that starts up a container. If the container doesn't exist it creates it.
 
 It takes 1 command line argument to start the container and add it to `theia-net`:
 
@@ -18,7 +18,7 @@ For example:
 ./start zed
 ```
 
-To test the container it takes 2 arguments, the name and port number to publish:
+To test the container locally it takes 2 arguments, the name and port number to publish:
 
 ```
 ./start name port
@@ -29,4 +29,9 @@ For example:
 ```
 ./start zed 3000
 ```
+
+### stop_idles.sh
+
+This is a script that loops over all running containers and checks their log file.
+If the log file indicates that the theia window has been closed, and the timestamp of the log is older than 30 minutes, the container is stopped.
 

--- a/start.sh
+++ b/start.sh
@@ -18,7 +18,15 @@ PORT=$2
 USER_ID=1000
 GROUP_ID=1000
 IMAGE=zedchance/theia-sierra-ubuntu:$(arch)
-URL=cside-test.cf
+URL=theia.cs.sierracollege.edu
+CONTAINER_NAME="$WHOAMI"-theia
+
+# First check to see if container already exists
+if [[ $(docker ps --filter "name=$CONTAINER_NAME" --format "{{.Names}}") == $CONTAINER_NAME ]]
+then
+    docker start "$CONTAINER_NAME" > /dev/null
+    exit
+fi
 
 # Exit on command fail
 set -e
@@ -35,8 +43,8 @@ then
                                  -e VIRTUAL_HOST="$WHOAMI"."$URL" \
                                  -e LETSENCRYPT_HOST="$WHOAMI"."$URL" \
                                  -u "$USER_ID:$GROUP_ID" \
-                                 --name "$WHOAMI"-theia \
-                                 $IMAGE)
+                                 --name "$CONTAINER_NAME" \
+                                 "$IMAGE")
 else
     echo "Creating container from $IMAGE on port $PORT"
     CONTAINER_ID=$(docker create --security-opt seccomp=unconfined \
@@ -45,8 +53,8 @@ else
                                  --mount source="$WHOAMI"-storage,target=/home \
                                  -p 127.0.0.1:"$PORT":3000 \
                                  -u $USER_ID:$GROUP_ID \
-                                 --name "$WHOAMI"-theia \
-                                 $IMAGE)
+                                 --name "$CONTAINER_NAME" \
+                                 "$IMAGE")
 fi
 
 # Start container

--- a/start.sh
+++ b/start.sh
@@ -17,7 +17,7 @@ PORT=$2
 # Config
 USER_ID=1000
 GROUP_ID=1000
-IMAGE=zedchance/theia-sierra-ubuntu
+IMAGE=zedchance/theia-sierra-ubuntu:$(arch)
 URL=cside-test.cf
 
 # Exit on command fail
@@ -30,32 +30,37 @@ then
     CONTAINER_ID=$(docker create --security-opt seccomp=unconfined \
                                  --init \
                                  -it \
+                                 --mount source="$WHOAMI"-storage,target=/home \
                                  --network theia-net \
-                                 -e VIRTUAL_HOST=$WHOAMI.$URL \
-                                 -e LETSENCRYPT_HOST=$WHOAMI.$URL \
-                                 -u $USER_ID:$GROUP_ID \
-                                 --name $WHOAMI-theia \
+                                 -e VIRTUAL_HOST="$WHOAMI"."$URL" \
+                                 -e LETSENCRYPT_HOST="$WHOAMI"."$URL" \
+                                 -u "$USER_ID:$GROUP_ID" \
+                                 --name "$WHOAMI"-theia \
                                  $IMAGE)
 else
     echo "Creating container from $IMAGE on port $PORT"
     CONTAINER_ID=$(docker create --security-opt seccomp=unconfined \
                                  --init \
                                  -it \
-                                 -p 127.0.0.1:$PORT:3000 \
+                                 --mount source="$WHOAMI"-storage,target=/home \
+                                 -p 127.0.0.1:"$PORT":3000 \
                                  -u $USER_ID:$GROUP_ID \
-                                 --name $WHOAMI-theia \
+                                 --name "$WHOAMI"-theia \
                                  $IMAGE)
 fi
 
 # Start container
 echo "Starting container"
-docker start $CONTAINER_ID
+docker start "$CONTAINER_ID"
 
 # Rename user to specified whoami
 echo "Renaming user to $WHOAMI"
-docker exec -u root $CONTAINER_ID usermod -l $WHOAMI theia
+docker exec -u root "$CONTAINER_ID" usermod -l "$WHOAMI" theia
 
 # Add welcome message to container's project dir
 echo "Copying welcome message"
-docker cp WELCOME.md $CONTAINER_ID:/home/project/
+docker cp WELCOME.md "$CONTAINER_ID":/home/project/
+
+# All done
+echo "👍"
 

--- a/start.sh
+++ b/start.sh
@@ -41,7 +41,7 @@ then
     CONTAINER_ID=$(docker create --security-opt seccomp=unconfined \
                                  --init \
                                  -it \
-                                 --mount source="$VOLUME_NAME",target=/project \
+                                 --mount source="$VOLUME_NAME",target=/home \
                                  --network theia-net \
                                  -u "$USER_ID:$GROUP_ID" \
                                  --name "$CONTAINER_NAME" \
@@ -51,7 +51,7 @@ else
     CONTAINER_ID=$(docker create --security-opt seccomp=unconfined \
                                  --init \
                                  -it \
-                                 --mount source="$VOLUME_NAME",target=/project \
+                                 --mount source="$VOLUME_NAME",target=/home \
                                  -p 127.0.0.1:"$PORT":3000 \
                                  -u $USER_ID:$GROUP_ID \
                                  --name "$CONTAINER_NAME" \
@@ -66,9 +66,9 @@ docker start "$CONTAINER_ID"
 echo "Renaming user to $USERNAME"
 docker exec -u root "$CONTAINER_ID" usermod -l "$USERNAME" theia
 
-# Add welcome message to container's project dir
+# Add welcome message to container's home dir
 echo "Copying welcome message"
-docker cp WELCOME.md "$CONTAINER_ID":/project
+docker cp WELCOME.md "$CONTAINER_ID":/home
 
 # All done
 echo "👍"

--- a/start.sh
+++ b/start.sh
@@ -22,8 +22,9 @@ URL=theia.cs.sierracollege.edu
 CONTAINER_NAME="$WHOAMI"-theia
 
 # First check to see if container already exists
-if [[ $(docker ps --filter "name=$CONTAINER_NAME" --format "{{.Names}}") == $CONTAINER_NAME ]]
+if [[ $(docker ps -a --filter "name=$CONTAINER_NAME" --format "{{.Names}}") == $CONTAINER_NAME ]]
 then
+    echo "Starting $CONTAINER_NAME"
     docker start "$CONTAINER_NAME" > /dev/null
     exit
 fi

--- a/start.sh
+++ b/start.sh
@@ -19,14 +19,31 @@ PORT=$2
 USER_ID=1000
 GROUP_ID=1000
 
+# URL
+URL=cside-test.cf
+
 # Create container and get ID
 if test $# -eq 1
 then
     echo "Creating container from $IMAGE, adding to theia-net"
-    CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it --network theia-net -u $USER_ID:$GROUP_ID --name $WHOAMI-theia $IMAGE)
+    CONTAINER_ID=$(docker create --security-opt seccomp=unconfined \
+                                 --init \
+                                 -it \
+                                 --network theia-net \
+                                 -e VIRTUAL_HOST=$WHOAMI.$URL \
+                                 -e LETSENCRYPT_HOST=$WHOAMI.$URL \
+                                 -u $USER_ID:$GROUP_ID \
+                                 --name $WHOAMI-theia \
+                                 $IMAGE)
 else
     echo "Creating container from $IMAGE on port $PORT"
-    CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it -p 127.0.0.1:$PORT:3000 -u $USER_ID:$GROUP_ID --name $WHOAMI-theia $IMAGE)
+    CONTAINER_ID=$(docker create --security-opt seccomp=unconfined \
+                                 --init \
+                                 -it \
+                                 -p 127.0.0.1:$PORT:3000 \
+                                 -u $USER_ID:$GROUP_ID \
+                                 --name $WHOAMI-theia \
+                                 $IMAGE)
 fi
 
 # Start container

--- a/start.sh
+++ b/start.sh
@@ -33,10 +33,7 @@ fi
 echo "Starting container"
 docker start $CONTAINER_ID
 
-# Rename user to specified whoami, and setup sudoers
-echo "Setting up sudoers"
-docker exec -u root $CONTAINER_ID bash -c "echo '$WHOAMI ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"
-
+# Rename user to specified whoami
 echo "Renaming user to $WHOAMI"
 docker exec -u root $CONTAINER_ID usermod -l $WHOAMI theia
 

--- a/start.sh
+++ b/start.sh
@@ -25,7 +25,10 @@ CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it --netw
 echo "Starting container"
 docker start $CONTAINER_ID
 
-# Rename user to specified whoami
+# Rename user to specified whoami, and setup sudoers
+echo "Setting up sudoers"
+docker exec -u root $CONTAINER_ID bash -c "echo '$WHOAMI ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"
+
 echo "Renaming user to $WHOAMI"
 docker exec -u root $CONTAINER_ID usermod -l $WHOAMI theia
 

--- a/start.sh
+++ b/start.sh
@@ -41,8 +41,6 @@ then
                                  -it \
                                  --mount source="$WHOAMI"-storage,target=/home \
                                  --network theia-net \
-                                 -e VIRTUAL_HOST="$WHOAMI"."$URL" \
-                                 -e LETSENCRYPT_HOST="$WHOAMI"."$URL" \
                                  -u "$USER_ID:$GROUP_ID" \
                                  --name "$CONTAINER_NAME" \
                                  "$IMAGE")

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,9 @@
 # Check for command line arguments
-if test $# -lt 2
+if test $# -ne 1
 then
-    echo "ERROR: Not enough command line arguments"
-    echo "Usage: $0 port_number user_name"
-    echo "Example: $0 3000 zed"
+    echo "ERROR: Incorrect command line arguments"
+    echo "Usage: $0 user_name"
+    echo "Example: $0 zed"
     exit 1
 fi
 
@@ -11,16 +11,15 @@ fi
 IMAGE=zedchance/theia-sierra-ubuntu
 
 # Command line arguments
-PORT=$1
-WHOAMI=$2
+WHOAMI=$1
 
 # Theia user and group ids
 USER_ID=1000
 GROUP_ID=1000
 
 # Create container and get ID
-echo "Creating container from $IMAGE image on port $PORT"
-CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it -p 127.0.0.1:$PORT:3000 -u $USER_ID:$GROUP_ID --name $WHOAMI-theia-$PORT $IMAGE)
+echo "Creating container from $IMAGE image"
+CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it --network theia-net -u $USER_ID:$GROUP_ID --name $WHOAMI-theia $IMAGE)
 
 # Start container
 echo "Starting container"
@@ -30,6 +29,7 @@ docker start $CONTAINER_ID
 echo "Renaming user to $WHOAMI"
 docker exec -u root $CONTAINER_ID usermod -l $WHOAMI theia
 
+# Add welcome message to container's project dir
 echo "Copying welcome message"
 docker cp WELCOME.md $CONTAINER_ID:/home/project/
 

--- a/start.sh
+++ b/start.sh
@@ -8,19 +8,18 @@ then
     exit 1
 fi
 
-# Image
-IMAGE=zedchance/theia-sierra-ubuntu
-
 # Command line arguments
 WHOAMI=$1
 PORT=$2
 
-# Theia user and group ids
+# Config
 USER_ID=1000
 GROUP_ID=1000
-
-# URL
+IMAGE=zedchance/theia-sierra-ubuntu
 URL=cside-test.cf
+
+# Exit on command fail
+set -e
 
 # Create container and get ID
 if test $# -eq 1

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,10 @@
 # Check for command line arguments
-if test $# -ne 1
+if test $# -lt 1
 then
     echo "ERROR: Incorrect command line arguments"
-    echo "Usage: $0 user_name"
+    echo "Usage: $0 user_name [port_number]"
     echo "Example: $0 zed"
+    echo "Example: $0 zed 3000"
     exit 1
 fi
 
@@ -12,14 +13,21 @@ IMAGE=zedchance/theia-sierra-ubuntu
 
 # Command line arguments
 WHOAMI=$1
+PORT=$2
 
 # Theia user and group ids
 USER_ID=1000
 GROUP_ID=1000
 
 # Create container and get ID
-echo "Creating container from $IMAGE image"
-CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it --network theia-net -u $USER_ID:$GROUP_ID --name $WHOAMI-theia $IMAGE)
+if test $# -eq 1
+then
+    echo "Creating container from $IMAGE, adding to theia-net"
+    CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it --network theia-net -u $USER_ID:$GROUP_ID --name $WHOAMI-theia $IMAGE)
+else
+    echo "Creating container from $IMAGE on port $PORT"
+    CONTAINER_ID=$(docker create --security-opt seccomp=unconfined --init -it -p 127.0.0.1:$PORT:3000 -u $USER_ID:$GROUP_ID --name $WHOAMI-theia $IMAGE)
+fi
 
 # Start container
 echo "Starting container"

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check for command line arguments
 if test $# -lt 1
 then

--- a/stop_idles.sh
+++ b/stop_idles.sh
@@ -23,7 +23,12 @@ do
     then
         echo "Closed container found: $CONTAINER_ID"
         NOW=$(date +%s)
+
+        # Date command on macOS
         THEN=$(date -jf "%Y-%m-%dT%H:%M:%S" "$TIMESTAMP" "+%s")
+        # Date command on linux
+        # THEN=$(date -d "$TIMESTAMP" +%s)
+
         # +28800 to compensate for PST to UTC, fix this
         DIFF=$(expr "$NOW" - "$THEN" + 28800)
 

--- a/stop_idles.sh
+++ b/stop_idles.sh
@@ -1,53 +1,57 @@
 #!/bin/bash
 
-# Config
-INACTIVE="All frontend contributions have been stopped"
+# Stop messages
+INACTIVE="Changed application state from 'ready' to 'closing_window'"
+ERROR="Connection got disposed"
+
+# 30 min timeout
 TIMEOUT=1800
 
 # Loop thru running containers
 for CONTAINER in $(docker ps --format "{{.Names}}")
 do
-    # Get latest log entry
-    LOG=$(docker container logs -t -n 1 "$CONTAINER")
+    # For each of the last 11 log entries
+    docker container logs -t -n 11 "$CONTAINER" | while read -r entry
+    do
+        # Timestamp is the first 19 chars of the log
+        TIMESTAMP=${entry:0:19}
 
-    # Timestamp is the first 30 chars of the log
-    TIMESTAMP=${LOG:0:19}
-
-    # Debug
-    # echo ""
-    # echo "Container ID: $CONTAINER"
-    # echo "Log: ${LOG:31:100}"
-    # echo "Timestamp: $TIMESTAMP"
-
-    # Check to see if the log entry is the inactive message
-    if [[ $LOG == *"$INACTIVE"* ]]
-    then
-        echo "Closed container found: $CONTAINER"
-
-        # Current time
-        NOW=$(date +%s)
-
-        # Date command on macOS
-        THEN=$(date -jf "%Y-%m-%dT%H:%M:%S" "$TIMESTAMP" "+%s")
-        # Date command on linux
-        # THEN=$(date -d "$TIMESTAMP" +%s)
-
-        # Calculate idle time
-        # +28800 to compensate for PST to UTC, fix this
-        DIFF=$((NOW - THEN + 28800))
-        IDLE_MIN=$((DIFF / 60))
-
-        # Debug
-        # echo "    Now : $NOW"
-        # echo "    Then: $THEN"
-        # echo "    Diff: $DIFF"
-        echo "    $CONTAINER has been idle for $IDLE_MIN minutes"
-
-        if [[ $DIFF -gt $TIMEOUT ]]
+        # Check to see if the log entry is the inactive message
+        if [[ $entry == *"$INACTIVE"* || $entry == *"$ERROR"* ]]
         then
-            echo "    $CONTAINER has exceeded time out, stopping..."
-            docker stop "$CONTAINER" > /dev/null
+            # Current time
+            NOW=$(date +%s)
+
+            # Date command on macOS
+            # THEN=$(date -jf "%Y-%m-%dT%H:%M:%S" "$TIMESTAMP" "+%s")
+            # Date command on linux
+            THEN=$(date -d "$TIMESTAMP" +%s)
+
+            # Calculate idle time
+            # +28800 to compensate for PST to UTC, fix this
+            DIFF=$((NOW - THEN + 28800))
+            IDLE_MIN=$((DIFF / 60))
+
+            # Debug
+            # echo "Closed container found: $CONTAINER"
+            # echo "    Now : $NOW"
+            # echo "    Then: $THEN"
+            # echo "    Diff: $DIFF"
+            # echo "    Log: ${entry:31:100}"
+            # echo "    Timestamp: $TIMESTAMP"
+
+            # Check to see if container has timed out
+            if [[ $DIFF -gt $TIMEOUT ]]
+            then
+                echo "$0: $CONTAINER has exceeded time out, stopping..."
+                docker stop "$CONTAINER" > /dev/null
+            else
+                echo "$0: $CONTAINER has been idle for $IDLE_MIN minutes"
+            fi
+
+            # Break because we found the inactive/error message
+            break
         fi
-    fi
+    done
 done
 

--- a/stop_idles.sh
+++ b/stop_idles.sh
@@ -5,23 +5,23 @@ INACTIVE="All frontend contributions have been stopped"
 TIMEOUT=1800
 
 # Loop thru running containers
-for CONTAINER_ID in $(docker ps -q)
+for CONTAINER in $(docker ps --format {{.Names}})
 do
     # Get latest log entry
-    LOG=$(docker container logs -t -n 1 "$CONTAINER_ID")
+    LOG=$(docker container logs -t -n 1 "$CONTAINER")
 
     # Timestamp is the first 30 chars of the log
     TIMESTAMP=${LOG:0:19}
 
     # Debug
-    # echo "Container ID: $CONTAINER_ID"
+    # echo "Container ID: $CONTAINER"
     # echo "Log: $LOG"
     # echo "Timestamp: $TIMESTAMP"
 
     # Check to see if the log entry is the inactive message
     if [[ $LOG == *"$INACTIVE"* ]]
     then
-        echo "Closed container found: $CONTAINER_ID"
+        echo "Closed container found: $CONTAINER"
         NOW=$(date +%s)
 
         # Date command on macOS
@@ -39,13 +39,13 @@ do
 
         if [[ $DIFF -gt $TIMEOUT ]]
         then
-            echo "$CONTAINER_ID has exceeded time out, stopping..."
-            docker stop $CONTAINER_ID
+            echo "    $CONTAINER has exceeded time out, stopping..."
+            docker stop $CONTAINER
+            echo ""
         else
             IDLE_MIN=$(expr $DIFF / 60)
-            echo "$CONTAINER_ID has been idle for $IDLE_MIN minutes"
+            echo "    $CONTAINER has been idle for $IDLE_MIN minutes"
         fi
     fi
-    echo "---"
 done
 

--- a/stop_idles.sh
+++ b/stop_idles.sh
@@ -43,7 +43,7 @@ do
         if [[ $DIFF -gt $TIMEOUT ]]
         then
             echo "    $CONTAINER has exceeded time out, stopping..."
-            docker stop $CONTAINER
+            docker stop $CONTAINER > /dev/null
         fi
     fi
 done

--- a/stop_idles.sh
+++ b/stop_idles.sh
@@ -29,8 +29,11 @@ do
         # Date command on linux
         # THEN=$(date -d "$TIMESTAMP" +%s)
 
+        # Calculate idle time
         # +28800 to compensate for PST to UTC, fix this
         DIFF=$(expr "$NOW" - "$THEN" + 28800)
+        IDLE_MIN=$(expr $DIFF / 60)
+        echo "    $CONTAINER has been idle for $IDLE_MIN minutes"
 
         # Debug
         # echo "Now : $NOW"
@@ -41,10 +44,6 @@ do
         then
             echo "    $CONTAINER has exceeded time out, stopping..."
             docker stop $CONTAINER
-            echo ""
-        else
-            IDLE_MIN=$(expr $DIFF / 60)
-            echo "    $CONTAINER has been idle for $IDLE_MIN minutes"
         fi
     fi
 done

--- a/stop_idles.sh
+++ b/stop_idles.sh
@@ -5,7 +5,7 @@ INACTIVE="All frontend contributions have been stopped"
 TIMEOUT=1800
 
 # Loop thru running containers
-for CONTAINER in $(docker ps --format {{.Names}})
+for CONTAINER in $(docker ps --format "{{.Names}}")
 do
     # Get latest log entry
     LOG=$(docker container logs -t -n 1 "$CONTAINER")
@@ -14,14 +14,17 @@ do
     TIMESTAMP=${LOG:0:19}
 
     # Debug
+    # echo ""
     # echo "Container ID: $CONTAINER"
-    # echo "Log: $LOG"
+    # echo "Log: ${LOG:31:100}"
     # echo "Timestamp: $TIMESTAMP"
 
     # Check to see if the log entry is the inactive message
     if [[ $LOG == *"$INACTIVE"* ]]
     then
         echo "Closed container found: $CONTAINER"
+
+        # Current time
         NOW=$(date +%s)
 
         # Date command on macOS
@@ -31,19 +34,19 @@ do
 
         # Calculate idle time
         # +28800 to compensate for PST to UTC, fix this
-        DIFF=$(expr "$NOW" - "$THEN" + 28800)
-        IDLE_MIN=$(expr $DIFF / 60)
-        echo "    $CONTAINER has been idle for $IDLE_MIN minutes"
+        DIFF=$((NOW - THEN + 28800))
+        IDLE_MIN=$((DIFF / 60))
 
         # Debug
-        # echo "Now : $NOW"
-        # echo "Then: $THEN"
-        # echo "Diff: $DIFF"
+        # echo "    Now : $NOW"
+        # echo "    Then: $THEN"
+        # echo "    Diff: $DIFF"
+        echo "    $CONTAINER has been idle for $IDLE_MIN minutes"
 
         if [[ $DIFF -gt $TIMEOUT ]]
         then
             echo "    $CONTAINER has exceeded time out, stopping..."
-            docker stop $CONTAINER > /dev/null
+            docker stop "$CONTAINER" > /dev/null
         fi
     fi
 done

--- a/stop_idles.sh
+++ b/stop_idles.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Config
+INACTIVE="All frontend contributions have been stopped"
+TIMEOUT=1800
+
+# Loop thru running containers
+for CONTAINER_ID in $(docker ps -q)
+do
+    # Get latest log entry
+    LOG=$(docker container logs -t -n 1 "$CONTAINER_ID")
+
+    # Timestamp is the first 30 chars of the log
+    TIMESTAMP=${LOG:0:19}
+
+    # Debug
+    # echo "Container ID: $CONTAINER_ID"
+    # echo "Log: $LOG"
+    # echo "Timestamp: $TIMESTAMP"
+
+    # Check to see if the log entry is the inactive message
+    if [[ $LOG == *"$INACTIVE"* ]]
+    then
+        echo "Closed container found: $CONTAINER_ID"
+        NOW=$(date +%s)
+        THEN=$(date -jf "%Y-%m-%dT%H:%M:%S" "$TIMESTAMP" "+%s")
+        # +28800 to compensate for PST to UTC, fix this
+        DIFF=$(expr "$NOW" - "$THEN" + 28800)
+
+        # Debug
+        # echo "Now : $NOW"
+        # echo "Then: $THEN"
+        # echo "Diff: $DIFF"
+
+        if [[ $DIFF -gt $TIMEOUT ]]
+        then
+            echo "$CONTAINER_ID has exceeded time out, stopping..."
+            docker stop $CONTAINER_ID
+        else
+            IDLE_MIN=$(expr $DIFF / 60)
+            echo "$CONTAINER_ID has been idle for $IDLE_MIN minutes"
+        fi
+    fi
+    echo "---"
+done
+

--- a/theia-sierra-ubuntu/Dockerfile
+++ b/theia-sierra-ubuntu/Dockerfile
@@ -91,18 +91,19 @@ RUN apt-get update && \
     apt-get clean
 
 # User account
-RUN adduser --disabled-password --gecos '' theia
-# ADD settings.json /home/theia/.theia/
-RUN chmod g+rw /home && \
-    mkdir -p /home/project && \
-    chown -R theia:theia /home/theia && \
-    chown -R theia:theia /home/project && \
+RUN adduser --disabled-password --gecos '' --home /home theia && \
+    cp -a /etc/skel/. /home && \
+    chown -R theia:theia /home && \
+    chmod g+rw /home && \
+# Theia install location
+    mkdir -p /theia && \
+    chown -R theia:theia /theia && \
 # Allow sudo use without password
     echo "%theia ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Theia application
 USER theia
-WORKDIR /home/theia
+WORKDIR /theia
 ADD $version.package.json ./package.json
 
 RUN yarn --pure-lockfile && \
@@ -118,7 +119,7 @@ RUN yarn --pure-lockfile && \
 
 EXPOSE 3000
 ENV SHELL=/bin/bash \
-    THEIA_DEFAULT_PLUGINS=local-dir:/home/theia/plugins
+    THEIA_DEFAULT_PLUGINS=local-dir:/theia/plugins
 
-ENTRYPOINT [ "node", "/home/theia/src-gen/backend/main.js", "/home/project", "--hostname=0.0.0.0" ]
-# ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]
+ENTRYPOINT [ "node", "/theia/src-gen/backend/main.js", "/home", "--hostname=0.0.0.0" ]
+

--- a/theia-sierra-ubuntu/Dockerfile
+++ b/theia-sierra-ubuntu/Dockerfile
@@ -16,6 +16,7 @@ ARG version=sierra
 # Common deps
 RUN apt-get update && \
     apt-get -y install build-essential \
+                       sudo \
                        curl \
                        git \
                        python \

--- a/theia-sierra-ubuntu/Dockerfile
+++ b/theia-sierra-ubuntu/Dockerfile
@@ -96,7 +96,9 @@ RUN adduser --disabled-password --gecos '' theia
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     chown -R theia:theia /home/theia && \
-    chown -R theia:theia /home/project;
+    chown -R theia:theia /home/project && \
+# Allow sudo use without password
+    echo "%theia ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Theia application
 USER theia

--- a/theia-sierra-ubuntu/build.sh
+++ b/theia-sierra-ubuntu/build.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
-# Build theia-sierra-ubuntu image, defaulting to amd64 arch
-if test $# -lt 1
-then
-    ARCH=$(arch)
-else
-    ARCH=$1
-fi
+# Default to system's arch
+ARCH=${1:-$(arch)}
 
 echo "Building with $ARCH architecture"
-docker buildx build --platform linux/$ARCH -t zedchance/theia-sierra-ubuntu:$ARCH .
+docker buildx build --platform linux/"$ARCH" -t zedchance/theia-sierra-ubuntu:"$ARCH" .
 

--- a/theia-sierra-ubuntu/build.sh
+++ b/theia-sierra-ubuntu/build.sh
@@ -1,2 +1,2 @@
-# Build theia-sierra-glibc image command
+# Build theia-sierra-ubuntu image command
 docker build --no-cache --build-arg version=sierra -t zedchance/theia-sierra-ubuntu .

--- a/theia-sierra-ubuntu/build.sh
+++ b/theia-sierra-ubuntu/build.sh
@@ -1,2 +1,13 @@
-# Build theia-sierra-ubuntu image command
-docker build --no-cache --build-arg version=sierra -t zedchance/theia-sierra-ubuntu .
+#!/bin/bash
+
+# Build theia-sierra-ubuntu image, defaulting to amd64 arch
+if test $# -lt 1
+then
+    ARCH=$(arch)
+else
+    ARCH=$1
+fi
+
+echo "Building with $ARCH architecture"
+docker buildx build --platform linux/$ARCH -t zedchance/theia-sierra-ubuntu:$ARCH .
+

--- a/theia-sierra-ubuntu/sierra.package.json
+++ b/theia-sierra-ubuntu/sierra.package.json
@@ -10,13 +10,7 @@
                 "preferences": {
                     "files.enableTrash": false,
                     "files.exclude": {
-                        ".cache": true,
-                        ".npm": true,
-                        ".yarn": true,
-                        ".theia": true,
-                        ".bashrc": true,
-                        ".bash_logout": true,
-                        ".profile": true
+                        ".*": true
                     }
                 }
             }

--- a/theia-sierra-ubuntu/sierra.package.json
+++ b/theia-sierra-ubuntu/sierra.package.json
@@ -8,7 +8,16 @@
             "config": {
                 "applicationName": "Theia IDE",
                 "preferences": {
-                    "files.enableTrash": false
+                    "files.enableTrash": false,
+                    "files.exclude": {
+                        ".cache": true,
+                        ".npm": true,
+                        ".yarn": true,
+                        ".theia": true,
+                        ".bashrc": true,
+                        ".bash_logout": true,
+                        ".profile": true
+                    }
                 }
             }
         }


### PR DESCRIPTION
The `start.sh` script doesn't publish the ports of the Docker containers anymore, in favor of `--network theia-net`. Now it is added to the internal network `theia-net`.

The `port_number` has been removed from the syntax of the script, now its simply
```
./start zed
```